### PR TITLE
fix: render code blocks as code instead of one token per line

### DIFF
--- a/thenewprinter/app/globals.css
+++ b/thenewprinter/app/globals.css
@@ -208,6 +208,20 @@
   font-family: 'EB Garamond', Georgia, serif;
 }
 
+/* Code blocks: Courier first so on-screen wrapping matches the PDF's
+   standard Courier metrics exactly (see MONO_ADVANCE_RATIO in layout-engine). */
+.block-code {
+  border-left: 2px solid #999;
+  padding-left: 8px;
+  background: #f2f2f2;
+}
+
+.block-code .code-line {
+  font-size: 10px;
+  font-family: 'Courier New', Courier, ui-monospace, monospace;
+  color: #1a1a1a;
+}
+
 .block-list .text-line {
   font-size: 12px;
   font-family: 'EB Garamond', Georgia, serif;

--- a/thenewprinter/components/ArticleBlock.tsx
+++ b/thenewprinter/components/ArticleBlock.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { ColumnBreakHandle } from './ColumnBreakHandle';
-import { LIST_ITEM_GAP_PX, LIST_BLOCK_PADDING_PX } from '@/lib/layout-engine';
+import { LIST_ITEM_GAP_PX, LIST_BLOCK_PADDING_PX, CODE_BLOCK_PADDING_PX } from '@/lib/layout-engine';
 import type { RenderedBlock } from '@/lib/types';
 
 interface Props {
@@ -34,6 +34,24 @@ export function ArticleBlock({ rendered, onInsertBreakAfter, onRemoveImage }: Pr
             <ColumnBreakHandle onInsert={onInsertBreakAfter} />
           </div>
         )}
+      </div>
+    );
+  }
+
+  if (block.type === 'code') {
+    return (
+      <div
+        className="block block-code"
+        style={{ paddingTop: CODE_BLOCK_PADDING_PX, paddingBottom: CODE_BLOCK_PADDING_PX }}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      >
+        {lines.map((line, i) => (
+          <div key={i} className="code-line" style={{ lineHeight: `${lineHeight}px`, whiteSpace: 'pre' }}>
+            {line || '\u00A0'}
+          </div>
+        ))}
+        {hovered && <ColumnBreakHandle onInsert={onInsertBreakAfter} />}
       </div>
     );
   }

--- a/thenewprinter/lib/extract.ts
+++ b/thenewprinter/lib/extract.ts
@@ -51,7 +51,7 @@ export async function extractArticle(rawUrl: string): Promise<ExtractResult> {
       allowedTags: [
         'p', 'br', 'b', 'i', 'em', 'strong', 'a', 'ul', 'ol', 'li',
         'h1', 'h2', 'h3', 'h4', 'blockquote', 'img', 'figure', 'figcaption',
-        'div', 'span',
+        'div', 'span', 'pre', 'code',
       ],
       allowedAttributes: {
         'a': ['href', 'title'],

--- a/thenewprinter/lib/layout-engine.ts
+++ b/thenewprinter/lib/layout-engine.ts
@@ -6,6 +6,17 @@ export const LIST_ITEM_GAP_PX    = 6;  // gap between list items
 export const LIST_BLOCK_PADDING_PX = 6;  // top + bottom padding of a list block
 const BLOCKQUOTE_INDENT_PX = 11; // 3mm at 96dpi — subtracted from wrap width
 
+export const CODE_BLOCK_PADDING_PX = 5;  // top + bottom padding of a code block
+export const CODE_INDENT_PX        = 10; // left rule + gutter before the first glyph
+/**
+ * Advance width of one glyph as a fraction of the font size. Courier — the PDF
+ * standard font we draw code with — and Courier New, the first face in the CSS
+ * stack, are both exactly 0.6, so code wraps identically on screen and in the
+ * PDF without having to measure text. Any narrower fallback only leaves a wider
+ * right gutter, never an overflow.
+ */
+const MONO_ADVANCE_RATIO = 0.6;
+
 const FONTS = {
   body: '9pt/1.45 EB Garamond, Georgia, serif',
   h1: 'bold 20pt/1.15 EB Garamond, Georgia, serif',
@@ -13,6 +24,7 @@ const FONTS = {
   h3: 'bold 10pt/1.3 EB Garamond, Georgia, serif',
   h4: 'bold 9pt/1.3 EB Garamond, Georgia, serif',
   blockquote: 'italic 9pt/1.45 EB Garamond, Georgia, serif',
+  code: '7.5pt/1.35 Courier New, Courier, monospace',
 } as const;
 
 function parseLineHeightPx(font: string): number {
@@ -22,6 +34,53 @@ function parseLineHeightPx(font: string): number {
   const multiplier = parseFloat(match[2]);
   // 1pt ≈ 1.333px at 96dpi
   return ptSize * 1.333 * multiplier;
+}
+
+function parseFontSizePx(font: string): number {
+  const match = font.match(/(\d+(?:\.\d+)?)pt/);
+  return match ? parseFloat(match[1]) * 1.333 : 12;
+}
+
+/**
+ * Hard-wrap code to the column width. Prefers to break just after a separator so
+ * a split lands between tokens rather than inside one, and hangs the remainder
+ * at the original line's indentation so the shape of the code survives.
+ */
+function wrapCodeLines(lines: string[], colWidthPx: number): string[] {
+  const charWidthPx = parseFontSizePx(FONTS.code) * MONO_ADVANCE_RATIO;
+  const maxChars = Math.max(12, Math.floor((colWidthPx - CODE_INDENT_PX) / charWidthPx));
+
+  const wrapped: string[] = [];
+  for (const line of lines) {
+    if (line.length <= maxChars) {
+      wrapped.push(line);
+      continue;
+    }
+
+    const hang = line.match(/^ */)![0] + '  ';
+    let rest = line;
+    let prefix = '';
+
+    for (;;) {
+      const budget = maxChars - prefix.length;
+      if (rest.length <= budget) break;
+
+      // A space is cut before, every other separator after it — so look for the
+      // latter one character earlier to keep the cut inside the budget.
+      const separator = Math.max(
+        rest.slice(0, budget + 1).lastIndexOf(' '),
+        ...[',', '(', '[', '{', '.', '='].map((c) => rest.slice(0, budget).lastIndexOf(c) + 1)
+      );
+      // Only honour a separator far enough right to be worth the ragged edge;
+      // otherwise break mid-token, flush with the column edge.
+      const cut = separator > budget * 0.6 ? separator : budget;
+      wrapped.push(prefix + rest.slice(0, cut).trimEnd());
+      rest = rest.slice(cut).replace(/^ +/, '');
+      prefix = hang.length < maxChars - 8 ? hang : '';
+    }
+    wrapped.push(prefix + rest);
+  }
+  return wrapped;
 }
 
 function estimateImageHeight(
@@ -110,6 +169,39 @@ export function layoutBlocks(blocks: Block[], opts: LayoutOptions): PageContent[
       };
       currentColumns()[col].blocks.push(rb);
       usedHeight += imgHeight;
+      continue;
+    }
+
+    // Code: monospace, pre-wrapped, splittable across columns like a paragraph.
+    if (block.type === 'code') {
+      const lineHeight = parseLineHeightPx(FONTS.code);
+      const padding    = CODE_BLOCK_PADDING_PX * 2;
+      const wrapped    = wrapCodeLines(block.lines, opts.columnWidthPx);
+
+      let colLines: string[] = [];
+      const flush = () => {
+        if (colLines.length === 0) return;
+        currentColumns()[col].blocks.push({
+          blockIndex: i,
+          block,
+          lines: colLines,
+          lineHeight,
+          totalHeight: colLines.length * lineHeight + padding,
+        });
+        colLines = [];
+      };
+
+      usedHeight += padding;
+      for (const line of wrapped) {
+        if (usedHeight + lineHeight > currentColHeight()) {
+          flush();
+          advanceColumn();
+          usedHeight += padding;
+        }
+        colLines.push(line);
+        usedHeight += lineHeight;
+      }
+      flush();
       continue;
     }
 

--- a/thenewprinter/lib/parse-blocks.ts
+++ b/thenewprinter/lib/parse-blocks.ts
@@ -16,6 +16,40 @@ function normalizeText(el: Element): string {
   return (el.textContent ?? '').replace(/\s+/g, ' ').trim();
 }
 
+/**
+ * Text of a <pre>/<code>, keeping the line structure and indentation that
+ * normalizeText() would collapse. Leading/trailing blank lines are dropped and
+ * any indentation shared by every line is removed, so code reads well in a
+ * narrow print column.
+ */
+function codeLines(el: Element): string[] {
+  const lines = (el.textContent ?? '')
+    .replace(/\r\n?/g, '\n')
+    .replace(/\t/g, '    ')
+    .split('\n')
+    .map((line) => line.replace(/\s+$/, ''));
+
+  while (lines.length && !lines[0]) lines.shift();
+  while (lines.length && !lines[lines.length - 1]) lines.pop();
+
+  const indents = lines.filter(Boolean).map((line) => line.match(/^ */)![0].length);
+  const common = indents.length ? Math.min(...indents) : 0;
+  return common ? lines.map((line) => line.slice(common)) : lines;
+}
+
+/**
+ * Syntax highlighters (Chroma, Pygments, Rouge) put line numbers in their own
+ * <pre> next to the code one, inside a two-cell table. Sanitizing drops the
+ * table but keeps both <pre>s, so the gutter would otherwise be parsed as a
+ * code block of its own — a column of bare, consecutive numbers.
+ */
+function isLineNumberGutter(lines: string[]): boolean {
+  if (lines.length < 2) return false;
+  const numbers = lines.map((line) => line.trim());
+  if (!numbers.every((n) => /^\d+$/.test(n))) return false;
+  return numbers.every((n, i) => i === 0 || Number(n) === Number(numbers[i - 1]) + 1);
+}
+
 function extractImage(img: Element): Block | null {
   const src = img.getAttribute('src') ?? '';
   if (!src || src.startsWith('data:')) return null;
@@ -54,6 +88,13 @@ function walkElement(el: Element, blocks: Block[]): void {
     // Also grab any text in the paragraph
     const text = normalizeText(el);
     if (text) blocks.push({ type: 'paragraph', text });
+    return;
+  }
+
+  // ── Code ──────────────────────────────────────────────────────────────────
+  if (tag === 'pre' || tag === 'code') {
+    const lines = codeLines(el);
+    if (lines.length && !isLineNumberGutter(lines)) blocks.push({ type: 'code', lines });
     return;
   }
 

--- a/thenewprinter/lib/pdf-generator.ts
+++ b/thenewprinter/lib/pdf-generator.ts
@@ -2,13 +2,16 @@
 // Do NOT add 'use client' — this file is imported by the server-side API route.
 
 import {
-  PDFDocument, PDFFont, PDFPage, rgb,
+  PDFDocument, PDFFont, PDFPage, StandardFonts, rgb,
   pushGraphicsState, popGraphicsState,
   moveTo, lineTo, closePath, clip, endPath,
 } from 'pdf-lib';
 import fontkit from '@pdf-lib/fontkit';
 import type { ExtractedArticle, PageContent, RenderedBlock, TemplateId } from './types';
-import { LIST_ITEM_GAP_PX, LIST_BLOCK_PADDING_PX } from './layout-engine';
+import {
+  LIST_ITEM_GAP_PX, LIST_BLOCK_PADDING_PX,
+  CODE_BLOCK_PADDING_PX, CODE_INDENT_PX,
+} from './layout-engine';
 
 // ─── WOFF1 → TTF conversion ──────────────────────────────────────────────────
 // @pdf-lib/fontkit's tinyInflate can mishandle WOFF1 table decompression,
@@ -134,6 +137,7 @@ const FONT_SIZES = {
   h3:        10,
   h4:         9,
   blockquote: 9,
+  code:     7.5,
   byline:     8,
   excerpt:    9,
   title:     20,
@@ -147,6 +151,7 @@ const LINE_HEIGHTS_PT = {
   h3:        10  * 1.3,
   h4:         9  * 1.3,
   blockquote: 9  * 1.45,
+  code:     7.5  * 1.35,
   byline:     8  * 1.4,
   excerpt:    9  * 1.45,
   title:     20  * 1.15,
@@ -155,6 +160,8 @@ const LINE_HEIGHTS_PT = {
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export type ImageFetcher = (url: string) => Promise<ArrayBuffer | null>;
+
+interface PdfFonts { regular: PDFFont; bold: PDFFont; italic: PDFFont; mono: PDFFont }
 
 export interface FontBuffers {
   regular: ArrayBuffer;
@@ -223,7 +230,7 @@ async function drawHeader(
   doc: PDFDocument,
   page: PDFPage,
   article: ExtractedArticle,
-  fonts: { regular: PDFFont; bold: PDFFont; italic: PDFFont },
+  fonts: PdfFonts,
   fetchImage: ImageFetcher,
 ): Promise<number> {
   let cursorFromTop = MARGIN_TOP;
@@ -336,7 +343,7 @@ async function drawHeader(
 
 // ─── Block drawing ────────────────────────────────────────────────────────────
 
-function blockFontAndSize(rb: RenderedBlock, fonts: { regular: PDFFont; bold: PDFFont; italic: PDFFont }) {
+function blockFontAndSize(rb: RenderedBlock, fonts: PdfFonts) {
   const { block } = rb;
   if (block.type === 'heading') {
     const size = FONT_SIZES[`h${block.level}` as keyof typeof FONT_SIZES] ?? 9;
@@ -345,6 +352,9 @@ function blockFontAndSize(rb: RenderedBlock, fonts: { regular: PDFFont; bold: PD
   }
   if (block.type === 'blockquote') {
     return { font: fonts.italic, size: FONT_SIZES.blockquote, lineHeightPt: LINE_HEIGHTS_PT.blockquote };
+  }
+  if (block.type === 'code') {
+    return { font: fonts.mono, size: FONT_SIZES.code, lineHeightPt: LINE_HEIGHTS_PT.code };
   }
   return { font: fonts.regular, size: FONT_SIZES.body, lineHeightPt: LINE_HEIGHTS_PT.body };
 }
@@ -357,7 +367,7 @@ async function drawBlock(
   colW: number,
   colTopY: number,
   offsetFromTop: number,
-  fonts: { regular: PDFFont; bold: PDFFont; italic: PDFFont },
+  fonts: PdfFonts,
   fetchImage: ImageFetcher,
 ): Promise<number> {
   const { block } = rb;
@@ -377,10 +387,26 @@ async function drawBlock(
   }
 
   const { font, size, lineHeightPt } = blockFontAndSize(rb, fonts);
-  const listItemGapPt  = LIST_ITEM_GAP_PX    * PX_TO_PT;
+  const listItemGapPt  = LIST_ITEM_GAP_PX      * PX_TO_PT;
   const listBlockPadPt = LIST_BLOCK_PADDING_PX * PX_TO_PT;
+  const codeBlockPadPt = CODE_BLOCK_PADDING_PX * PX_TO_PT;
+  const codeIndentPt   = CODE_INDENT_PX        * PX_TO_PT;
 
   if (block.type === 'list') offsetFromTop += listBlockPadPt;
+
+  if (block.type === 'code') {
+    // Tinted panel with a left rule, mirroring .block-code in globals.css.
+    const totalPt = rb.lines.length * lineHeightPt + codeBlockPadPt * 2;
+    page.drawRectangle({
+      x: colX, y: colTopY - offsetFromTop - totalPt,
+      width: colW, height: totalPt, color: rgb(0.949, 0.949, 0.949),
+    });
+    page.drawRectangle({
+      x: colX, y: colTopY - offsetFromTop - totalPt,
+      width: 1.5, height: totalPt, color: rgb(0.6, 0.6, 0.6),
+    });
+    offsetFromTop += codeBlockPadPt;
+  }
 
   if (block.type === 'blockquote') {
     const totalPt = rb.lines.filter(l => l !== '').length * lineHeightPt;
@@ -390,10 +416,16 @@ async function drawBlock(
     });
   }
 
-  const textX = block.type === 'blockquote' ? colX + 4 : colX;
+  const textX =
+    block.type === 'blockquote' ? colX + 4 :
+    block.type === 'code'       ? colX + codeIndentPt :
+    colX;
 
   for (const line of rb.lines) {
-    if (line === '') { offsetFromTop += listItemGapPt; continue; }
+    // An empty line means the inter-item gap in a list, but a real blank line
+    // of code — which still occupies a full line box.
+    if (line === '' && block.type === 'list') { offsetFromTop += listItemGapPt; continue; }
+    if (line === '') { offsetFromTop += lineHeightPt; continue; }
     safeDrawText(page, line, {
       x: textX,
       y: colTopY - offsetFromTop - lineHeightPt * 0.8,
@@ -403,6 +435,7 @@ async function drawBlock(
   }
 
   if (block.type === 'list') offsetFromTop += listBlockPadPt;
+  if (block.type === 'code') offsetFromTop += codeBlockPadPt;
 
   return offsetFromTop;
 }
@@ -431,6 +464,9 @@ export async function buildPdf(
   const regular = await doc.embedFont(regBuf,    { subset: false });
   const bold    = await doc.embedFont(boldBuf,   { subset: false });
   const italic  = await doc.embedFont(italicBuf, { subset: false });
+  // Courier is a PDF standard font: no bytes to ship, and its 0.6em advance is
+  // exactly what the layout engine assumed when it wrapped the code lines.
+  const mono    = await doc.embedFont(StandardFonts.Courier);
 
   // Disable OpenType ligature substitution (liga, clig) on all three fonts.
   // Without this, fontkit's GSUB maps "fi" → ligature glyph whose CID collides
@@ -447,7 +483,7 @@ export async function buildPdf(
     }
   }
 
-  const fonts   = { regular, bold, italic };
+  const fonts   = { regular, bold, italic, mono };
 
   const colCount = template === 'three-column' ? 3 : 2;
   const cols     = colPositions(colCount);

--- a/thenewprinter/lib/types.ts
+++ b/thenewprinter/lib/types.ts
@@ -16,6 +16,7 @@ export type Block =
   | { type: 'heading'; level: 1 | 2 | 3 | 4; text: string }
   | { type: 'image'; src: string; alt: string; naturalWidth?: number; naturalHeight?: number }
   | { type: 'blockquote'; text: string }
+  | { type: 'code'; lines: string[] }
   | { type: 'list'; ordered: boolean; items: string[] }
   | { type: 'column-break' };
 


### PR DESCRIPTION
## The report

> "Just used your printer, it's great. Only the code sections didn't work well, e.g. I tried this article — see Page 3."

[The Grammar of Data Engineering](https://www.ssp.sh/blog/grammar-data-engineering/) — [reproduction](https://thenewprinter.vercel.app/print?url=https%3A%2F%2Fwww.ssp.sh%2Fblog%2Fgrammar-data-engineering%2F&template=two-column). Every code sample printed as a vertical column of single tokens (`import` / `xorq.api` / `as` / `xo` / …), preceded by a column of bare line numbers 1–21.

## Cause

The sanitizer allowlist in `lib/extract.ts` had no `pre` or `code`, but did allow `span`. sanitize-html discards a disallowed tag while keeping its children, so this Chroma output:

```html
<table class="lntable"><tr>
  <td><pre><code><span class="lnt"> 1
</span>…</code></pre></td>
  <td><pre><code><span class="line"><span class="cl"><span class="kn">import</span> <span class="nn">xorq.api</span>…
```

came out of the sanitizer as a flat run of bare `<span>`s. `parse-blocks` treats `span` as a container, so every leaf highlighting span became its own `paragraph` block — one token per line. The line-number gutter, a second `<pre>` in a sibling table cell, arrived the same way and became 21 numbered paragraphs.

Verified against the live article before the fix:

```
{"type":"paragraph","text":"1"} … {"type":"paragraph","text":"21"}
{"type":"paragraph","text":"import"}
{"type":"paragraph","text":"xorq.api"}
{"type":"paragraph","text":"as"}
{"type":"paragraph","text":"xo"}
```

## The fix

- **`lib/extract.ts`** — allow `pre` and `code` through the sanitizer.
- **`lib/types.ts` / `lib/parse-blocks.ts`** — new `code` block. `codeLines()` keeps the newlines and indentation that `normalizeText()` would collapse, trims blank edges, and strips indentation common to every line so code reads well in a narrow column. `isLineNumberGutter()` drops a `<pre>` that is nothing but a run of consecutive bare integers — that's a highlighter gutter, never content.
- **`lib/layout-engine.ts`** — code is measured in Courier metrics and hard-wrapped to the column, preferring a break just after a separator (` , ( [ { . =`) and hanging the remainder at the line's own indent. A code block flows across columns and pages like a paragraph rather than overflowing.
- **`components/ArticleBlock.tsx`, `app/globals.css`, `lib/pdf-generator.ts`** — rendered as a tinted panel with a left rule, monospace on screen and in the PDF.

On the font: the PDF uses **standard Courier**, so there are no font bytes to ship. Its advance is exactly 0.6em, which is what the wrapper assumes and what `'Courier New'` (first in the CSS stack) also measures — screen and PDF break at identical points. A narrower fallback face only widens the right gutter; it can't overflow.

## After

Same article, page 3 — the 21-line sample is now one intact code block, gutter gone:

```
import xorq.api as xo

# Connect to engines
pg = xo.postgres.connect_env()
db = xo.duckdb.connect()
…
result = recent.join(
    nl_awards.into_backend(pg),
    ["playerID"]
)

result.execute()
```

## Verification

Driven through the real routes (`/api/extract`, `/print`, `/api/generate-pdf`) with Playwright, the same path the CLI uses.

- **Reported article**, two-column: 1 code fragment of 21 lines, widest line 53 chars, no wrapping needed. PDF renders the panel in Courier. Screenshot of page 3 confirms the fix.
- **Three-column** (narrower, forces wrapping): wraps at 36 chars with hanging indents, `awards = xo.examples.awards_players.` / `  fetch(backend=db)`. PDF: 200, valid.
- **Other code-heavy articles** — [joshwcomeau](https://www.joshwcomeau.com/css/interactive-guide-to-flexbox/) (7 pages, 2 code fragments), [jvns.ca](https://jvns.ca/blog/2024/11/18/how-to-import-a-javascript-library/) (4 pages, 10 fragments), [martinfowler](https://martinfowler.com/articles/patterns-of-distributed-systems/write-ahead-log.html) (no code, unchanged). No wrapped line exceeds the column budget.
- **Column splitting** — a synthetic 120-line block splits 58 / 58 / 4 across two columns and two pages, each fragment within the column height.
- **Parser edge cases** — Chroma gutter dropped while blank lines inside the code survive; plain highlight.js `pre > code`; a `<pre>` of genuinely numeric data (`2 4 8` / `16 32 64`) and non-consecutive numbers both kept as code; inline `<code>` stays inside its paragraph; whitespace-only `<pre>` yields nothing; prose blocks unchanged.
- `npm run build` passes. `npm run lint` reports the same one error and one warning as `main` — no new findings.

## Note, not addressed here

While testing I hit a **pre-existing** bug unrelated to this report: a long `<ul>` is laid out as one indivisible block, so a 87-item list on the jvns.ca article produces a block 1263px tall in a 990px column and overflows. Lists need the same across-column splitting code now has. Left out to keep this PR to the reported issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFZxGrQGUR456tcrtDouTj
